### PR TITLE
Add DBCopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ We welcome researchers to share related work to enrich this list or provide insi
             - [GraphRAG with Existing KGs](#graphrag-with-existing-kgs)
         - [Hybrid GraphRAG](#hybrid-graphrag)
     - [Knowledge Retrieval](#knowledge-retrieval)
+        - [Generative Retriever](#generative-retriever)
         - [Semantics Similarity-based Retriever](#semantics-similarity-based-retriever)
         - [Logical Reasoning-based Retriever](#logical-reasoning-based-retriever)
         - [LLM-based Retriever](#llm-based-retriever)
@@ -144,6 +145,9 @@ We welcome researchers to share related work to enrich this list or provide insi
 - (arXiv 2024) **Codexgraph: Bridging large language models and code repositories via code graph databases** [[Paper]](https://arXiv.org/abs/2408.03910)
 
 ## Knowledge Retrieval
+
+### Generative Retriever
+- (EDBT 2025) **DBCopilot: Natural Language Querying over Massive Databases via Schema Routing** [[Paper]](https://openproceedings.org/2025/conf/edbt/paper-209.pdf)
 
 ### Semantics Similarity-based Retriever
 - (AAAI 2024) **StructuGraphRAG: Structured Document-Informed Knowledge Graphs for Retrieval-Augmented Generation** [[Paper]](https://ojs.aaai.org/index.php/AAAI-SS/article/view/31798/33965)


### PR DESCRIPTION
I would like to introduce our related work, "DBCopilot: Natural Language Querying over Massive Databases via Schema Routing", which focuses on scaling NL2SQL to massive databases via **graph-based** generative schema retrieval. Our paper was accepted at EDBT 2025 and was awarded the Runner-Up for Best Research Paper.

I believe our work would fit well within either the Graphs for Knowledge Indexing (§IV) or Knowledge Retrieval (§V) (Generative Retrieval) and we are likely the first to combine generative retrieval with GraphRAG. Including our paper in your future versions could benefit your audience and highlight recent developments in this area. We would highly appreciate it if you could consider adding our paper to your references.

