### PR TITLE
Add KB Arena (knowledge graph + hybrid retrieval benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ To explore the applications of LLMs on graph tasks, we recommend the following r
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/FalkorDB/GraphRAG-SDK) GraphRAG-SDK: a specialized toolkit for building GraphRAG systems.
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/vitali87/code-graph-rag) Code-Graph-RAG: A graph-based RAG system that analyzes multi-language codebases using Tree-sitter, builds knowledge graphs, and enables natural language querying and editing via MCP server.
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/onestardao/WFGY) WFGY Problem Map: a specialized toolkit that defines 16 recurring failure modes that show up in RAG and LLM pipelines.
+- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/xmpuspus/kb-arena) KB Arena: benchmarks 9 retrieval architectures head-to-head on user-supplied docs, including a knowledge graph strategy (Neo4j, universal 5-node-type / 7-rel-type schema) and a hybrid strategy that fuses vector + graph via RRF with intent routing. Ships paired-bootstrap CIs and Wilcoxon p-values for honest GraphRAG vs vector vs hybrid comparisons.
 
 
 # 🍀 Citation


### PR DESCRIPTION
Adds [KB Arena](https://github.com/xmpuspus/kb-arena) to the Open-source Project section.

KB Arena is an open-source benchmark that runs nine architecturally distinct retrieval strategies head-to-head on user-supplied corpora. The two GraphRAG-relevant strategies:

- ``knowledge_graph`` — extraction-driven Neo4j graph using a universal 5-node-type / 7-rel-type schema (Topic, Component, Process, Config, Constraint + DEPENDS_ON, CONTAINS, CONNECTS_TO, TRIGGERS, CONFIGURES, ALTERNATIVE_TO, EXTENDS). Source provenance is stamped on every entity end-to-end so chunk-level retrieval matches against section ground truth.
- ``hybrid`` — RRF-fused vector + graph retrieval with three-stage intent routing (keyword scan → Haiku LLM → regex fallback). Domain-agnostic.

Why it matters for the GraphRAG community: the field still lacks a clean apples-to-apples way to say "graph beats vector on this corpus by X with p<Y." KB Arena ships paired-bootstrap 95% CIs and Wilcoxon paired two-sided p-values on per-question IR metrics (Recall@k, NDCG, MAP, R-Precision, bpref), so GraphRAG vs vector vs hybrid comparisons report effect size with statistical confidence rather than mean-only deltas.

- Active: v0.8.1 released 2026-05-21, 617 tests, MIT, on PyPI as ``kb-arena``
- Zenodo archive (concept DOI): [10.5281/zenodo.20319678](https://doi.org/10.5281/zenodo.20319678)
- Ships an aws-compute benchmark corpus (75 questions, 5 difficulty tiers, 35 with chunk-level ground truth) as a pedagogical baseline

Entry appended to the existing Open-source Project list following the badge-prefix format used by the other 14 entries. No other sections modified.