### PR TITLE
Add open-kgo to Open-source Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ To explore the applications of LLMs on graph tasks, we recommend the following r
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/vitali87/code-graph-rag) Code-Graph-RAG: A graph-based RAG system that analyzes multi-language codebases using Tree-sitter, builds knowledge graphs, and enables natural language querying and editing via MCP server.
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/onestardao/WFGY) WFGY Problem Map: a specialized toolkit that defines 16 recurring failure modes that show up in RAG and LLM pipelines.
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/topoteretes/cognee) Cognee: Open-source memory engine that turns data into knowledge graphs via an ECL pipeline, combining graph and vector retrieval for AI agents.
+- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/mloda-ai/open-kgo) open-kgo: One Python API over nine knowledge-graph backend families with ontology-validated traversals that reject semantically invalid hops, plus an agent-memory backend for AI agents.
 
 # 🍀 Citation
 If you find this survey helpful, please cite our paper:


### PR DESCRIPTION
Adds [open-kgo](https://github.com/mloda-ai/open-kgo) to the Open-source Project section, alongside KG-infrastructure peers like Cognee and Graphiti.

open-kgo provides one Python API over nine knowledge-graph backend families (NetworkX, RDF/SPARQL, Cypher, REST, agent memory, and others) and validates each traversal against a declared ontology, rejecting semantically invalid hops at query time. Relevant to GraphRAG as a typed, ontology-checked KG access/traversal layer (with an agent-memory backend). Apache-2.0, tested, demos run offline.